### PR TITLE
feat: add navigation examples to kitchen sink

### DIFF
--- a/example/examples/NavigationExamples.tsx
+++ b/example/examples/NavigationExamples.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import {
+    Flex,
+    Pagination,
+    Breadcrumbs,
+    Menu,
+    MenuButton,
+    MenuItem,
+} from '@aws-amplify/ui-react';
+
+export const NavigationExamples: React.FC = () => {
+    const [currentPage, setCurrentPage] = useState(1);
+
+    return (
+        <Flex direction="column" gap="1.5rem">
+            <Breadcrumbs
+                items={[
+                    { label: 'Home', href: '#' },
+                    { label: 'Library', href: '#library' },
+                    { label: 'Data', href: '#data' },
+                ]}
+            />
+            <Menu trigger={<MenuButton>Menu</MenuButton>}>
+                <MenuItem>Profile</MenuItem>
+                <MenuItem isDisabled>Settings</MenuItem>
+                <MenuItem>Sign out</MenuItem>
+            </Menu>
+            <Pagination
+                currentPage={currentPage}
+                totalPages={5}
+                onChange={(page) => setCurrentPage(page ?? 1)}
+            />
+        </Flex>
+    );
+};

--- a/example/examples/index.ts
+++ b/example/examples/index.ts
@@ -3,3 +3,4 @@ export { FormExamples } from './FormExamples';
 export { DataDisplayExamples } from './DataDisplayExamples';
 export { FeedbackExamples } from './FeedbackExamples';
 export { LayoutExamples } from './LayoutExamples';
+export { NavigationExamples } from './NavigationExamples';

--- a/example/src/KitchenSink.tsx
+++ b/example/src/KitchenSink.tsx
@@ -7,6 +7,7 @@ import {
      DataDisplayExamples,
      FeedbackExamples,
      LayoutExamples,
+     NavigationExamples,
 } from '../examples';
 
 const Section: React.FC<{ title: string; children: ReactNode }> = ({
@@ -43,6 +44,9 @@ const KitchenSink = () => (
           </Section>
           <Section title="Layout">
                <LayoutExamples />
+          </Section>
+          <Section title="Navigation">
+               <NavigationExamples />
           </Section>
      </Flex>
 );


### PR DESCRIPTION
## Summary
- showcase Breadcrumbs, Menu, and Pagination in a new NavigationExamples component
- export navigation demos and wire into KitchenSink

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c24b7fac832899ee0a1d46b7e06c