### PR TITLE
feat: expand kitchen sink example

### DIFF
--- a/example/examples/ButtonExamples.tsx
+++ b/example/examples/ButtonExamples.tsx
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
-import { Button, Flex } from '@aws-amplify/ui-react';
+import {
+     Button,
+     ButtonGroup,
+     Flex,
+     ToggleButton,
+     ToggleButtonGroup,
+} from '@aws-amplify/ui-react';
 
 export const ButtonExamples: React.FC = () => {
      const [loading, setLoading] = useState(false);
+     const [alignment, setAlignment] = useState('left');
      return (
           <Flex direction="column" gap="1rem">
                <Flex wrap="wrap" gap="0.5rem">
@@ -24,11 +31,23 @@ export const ButtonExamples: React.FC = () => {
                     >
                          Toggle Load
                     </Button>
-                    <Button variation="destructive">Destructive</Button>
                </Flex>
                <Flex wrap="wrap" gap="0.5rem">
-                    <Button>Full Width</Button>
+                    <Button width="100%">Full Width</Button>
                </Flex>
+               <ButtonGroup>
+                    <Button>First</Button>
+                    <Button>Second</Button>
+               </ButtonGroup>
+               <ToggleButtonGroup
+                    value={alignment}
+                    isExclusive
+                    onChange={(value) => setAlignment(value as string)}
+               >
+                    <ToggleButton value="left">Left</ToggleButton>
+                    <ToggleButton value="center">Center</ToggleButton>
+                    <ToggleButton value="right">Right</ToggleButton>
+               </ToggleButtonGroup>
           </Flex>
      );
 };

--- a/example/examples/DataDisplayExamples.tsx
+++ b/example/examples/DataDisplayExamples.tsx
@@ -12,6 +12,12 @@ import {
      TableBody,
      TableRow,
      TableCell,
+     Avatar,
+     Icon,
+     Image,
+     Placeholder,
+     Rating,
+     Collection,
 } from '@aws-amplify/ui-react';
 
 export const DataDisplayExamples: React.FC = () => {
@@ -23,6 +29,27 @@ export const DataDisplayExamples: React.FC = () => {
                     <Badge variation="warning">Warning</Badge>
                     <Badge variation="error">Error</Badge>
                </Flex>
+               <Flex gap="0.5rem" alignItems="center" wrap="wrap">
+                    <Avatar src="https://via.placeholder.com/40" alt="User Avatar" />
+                    <Rating value={4} maxValue={5} />
+                    <Icon
+                         ariaLabel="Star Icon"
+                         viewBox={{ minX: 0, minY: 0, width: 24, height: 24 }}
+                         paths={[
+                              {
+                                   d: 'M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z',
+                              },
+                         ]}
+                    />
+               </Flex>
+               <Image
+                    src="https://via.placeholder.com/150x80"
+                    alt="Example image"
+               />
+               <Placeholder width="100%" height="20px" />
+               <Collection type="list" items={['One', 'Two', 'Three']}>
+                    {(item, index) => <Text key={index}>{item}</Text>}
+               </Collection>
                <Card variation="elevated">
                     <Heading level={4}>Card Title</Heading>
                     <Text variation="tertiary">

--- a/example/examples/FeedbackExamples.tsx
+++ b/example/examples/FeedbackExamples.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Flex, Alert, Button } from '@aws-amplify/ui-react';
+import { Flex, Alert, Button, Loader, Message } from '@aws-amplify/ui-react';
 
 export const FeedbackExamples: React.FC = () => {
      const [visible, setVisible] = useState(true);
@@ -10,24 +10,33 @@ export const FeedbackExamples: React.FC = () => {
                </Button>
                {visible && (
                     <Flex direction="column" gap="0.75rem">
-                         <Alert
-                              variation="info"
-                              isDismissible={true}
-                              heading="Info Alert"
-                         >
-                              General informational message.
-                         </Alert>
-                         <Alert variation="success" heading="Success Alert">
-                              Action completed successfully.
-                         </Alert>
-                         <Alert variation="warning" heading="Warning Alert">
-                              Something may require attention.
-                         </Alert>
-                         <Alert variation="error" heading="Error Alert">
-                              An error occurred.
-                         </Alert>
-                    </Flex>
+                        <Alert
+                             variation="info"
+                             isDismissible={true}
+                             heading="Info Alert"
+                        >
+                             General informational message.
+                        </Alert>
+                        <Alert variation="success" heading="Success Alert">
+                             Action completed successfully.
+                        </Alert>
+                        <Alert variation="warning" heading="Warning Alert">
+                             Something may require attention.
+                        </Alert>
+                        <Alert variation="error" heading="Error Alert">
+                             An error occurred.
+                        </Alert>
+                   </Flex>
                )}
+               <Loader size="large" variation="linear" />
+               <Message
+                    variation="outlined"
+                    colorTheme="info"
+                    heading="Info Message"
+                    isDismissible
+               >
+                    Additional context for the user.
+               </Message>
           </Flex>
      );
 };

--- a/example/examples/FormExamples.tsx
+++ b/example/examples/FormExamples.tsx
@@ -12,10 +12,17 @@ import {
      SliderField,
      StepperField,
      PhoneNumberField,
+     SearchField,
+     Autocomplete,
 } from '@aws-amplify/ui-react';
 
 export const FormExamples: React.FC = () => {
      const [value, setValue] = useState('');
+     const fruitOptions = [
+          { id: 'apple', label: 'Apple' },
+          { id: 'banana', label: 'Banana' },
+          { id: 'cherry', label: 'Cherry' },
+     ];
      return (
           <Flex direction="column" gap="1.5rem">
                <TextField
@@ -74,6 +81,11 @@ export const FormExamples: React.FC = () => {
                     step={1}
                     defaultValue={3}
                     isDisabled={false}
+               />
+               <SearchField label="SearchField" placeholder="Search here" />
+               <Autocomplete
+                    label="Autocomplete"
+                    options={fruitOptions}
                />
           </Flex>
      );

--- a/example/examples/LayoutExamples.tsx
+++ b/example/examples/LayoutExamples.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, View, Heading, Text } from '@aws-amplify/ui-react';
+import { Flex, View, Heading, Text, Grid } from '@aws-amplify/ui-react';
 
 const boxStyle: React.CSSProperties = {
      backgroundColor: 'var(--amplify-colors-neutral-20)',
@@ -33,6 +33,14 @@ export const LayoutExamples: React.FC = () => {
                          <View style={boxStyle}>B2</View>
                     </Flex>
                </Flex>
+               <Heading level={5}>Grid (3 columns)</Heading>
+               <Grid templateColumns="repeat(3, 1fr)" gap="0.5rem">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                         <View key={i} style={boxStyle}>
+                              Cell {i + 1}
+                         </View>
+                    ))}
+               </Grid>
           </Flex>
      );
 };

--- a/example/examples/NavigationExamples.tsx
+++ b/example/examples/NavigationExamples.tsx
@@ -6,6 +6,7 @@ import {
     Menu,
     MenuButton,
     MenuItem,
+    Link,
 } from '@aws-amplify/ui-react';
 
 export const NavigationExamples: React.FC = () => {
@@ -30,6 +31,7 @@ export const NavigationExamples: React.FC = () => {
                 totalPages={5}
                 onChange={(page) => setCurrentPage(page ?? 1)}
             />
+            <Link href="#nav-link">Simple Link</Link>
         </Flex>
     );
 };


### PR DESCRIPTION
## Summary
- showcase grouped and toggle buttons
- add search and autocomplete fields
- demonstrate additional data-display and feedback components
- include grid layout and navigation link examples

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c4f063508328a74fdd7c345cc0a9